### PR TITLE
Use information from apiData for threadkey

### DIFF
--- a/src/nicodo/comment.rs
+++ b/src/nicodo/comment.rs
@@ -79,27 +79,30 @@ impl Session {
         let wayback_len = wayback_iter.len();
 
         for (index, current) in wayback_iter.enumerate() {
-            let body = get_body(Options {
-                info,
-                wayback: current.and_then(|c| {
-                    if let Some(waybackkey) = waybackkey.as_ref() {
-                        Some(WaybackOptions {
-                            waybackkey,
-                            wayback: c,
+            let body = get_body(
+                Options {
+                    info,
+                    wayback: current.and_then(|c| {
+                        if let Some(waybackkey) = waybackkey.as_ref() {
+                            Some(WaybackOptions {
+                                waybackkey,
+                                wayback: c,
+                            })
+                        } else {
+                            None
+                        }
+                    }),
+                    official: if let Some((threadkey, force_184)) = official_info.as_ref() {
+                        Some(OfficialOptions {
+                            threadkey,
+                            force_184,
                         })
                     } else {
                         None
-                    }
-                }),
-                official: if let Some((threadkey, force_184)) = official_info.as_ref() {
-                    Some(OfficialOptions {
-                        threadkey,
-                        force_184,
-                    })
-                } else {
-                    None
+                    },
                 },
-            });
+                wayback,
+            );
 
             let res = reqwest::Client::new()
                 .post(API_ENDPOINT)

--- a/src/nicodo/comment.rs
+++ b/src/nicodo/comment.rs
@@ -1,5 +1,5 @@
 use super::{
-    comment_body::{get_body, Options, WaybackOptions},
+    comment_body::{get_body, OfficialOptions, Options, WaybackOptions},
     Error, Info, Result, Session, Wayback,
 };
 use chrono::NaiveDateTime;
@@ -59,11 +59,17 @@ impl Session {
             Some(tid) => tid,
             None => return Err(Error::InvalidKey),
         };
+        let official_info = if let Some(t) = info.comment.thread_key_required_thread() {
+            Some((
+                t.thread_key.as_ref().expect(""),
+                if t.is_184_forced.expect("") { "1" } else { "0" },
+            ))
+        } else {
+            None
+        };
 
-        let wayback_info = if wayback.is_wayback() {
-            let (threadkey, force_184) = self.get_thread_key(&tid).await?;
-            let waybackkey = self.get_waybackkey(&tid).await?;
-            Some((threadkey, force_184, waybackkey))
+        let waybackkey = if wayback.is_wayback() {
+            Some(self.get_waybackkey(&tid).await?)
         } else {
             None
         };
@@ -76,10 +82,8 @@ impl Session {
             let body = get_body(Options {
                 info,
                 wayback: current.and_then(|c| {
-                    if let Some((threadkey, force_184, waybackkey)) = wayback_info.as_ref() {
+                    if let Some(waybackkey) = waybackkey.as_ref() {
                         Some(WaybackOptions {
-                            force_184,
-                            threadkey,
                             waybackkey,
                             wayback: c,
                         })
@@ -87,6 +91,14 @@ impl Session {
                         None
                     }
                 }),
+                official: if let Some((threadkey, force_184)) = official_info.as_ref() {
+                    Some(OfficialOptions {
+                        threadkey,
+                        force_184,
+                    })
+                } else {
+                    None
+                },
             });
 
             let res = reqwest::Client::new()

--- a/src/nicodo/comment_body.rs
+++ b/src/nicodo/comment_body.rs
@@ -1,4 +1,4 @@
-use crate::nicodo::info::CommentThread;
+use crate::{nicodo::info::CommentThread, Wayback};
 
 use super::Info;
 use serde::Serialize;
@@ -68,7 +68,7 @@ pub struct OfficialOptions<'a, 'b> {
     pub force_184: &'b str,
 }
 
-pub fn get_body(opts: Options) -> String {
+pub fn get_body(opts: Options, wayback: &Wayback) -> String {
     let rs = if opts.wayback.is_some() { 2 } else { 0 };
     let mut body: Vec<Element> = vec![Element::Ping(Ping {
         content: format!("rs:{}", rs),
@@ -153,7 +153,12 @@ pub fn get_body(opts: Options) -> String {
             .comment
             .threads
             .iter()
-            .filter(|t| t.is_active && (!opts.wayback.is_some() || t.is_thread_key_required))
+            .filter(|t| {
+                t.is_active
+                    && ((!wayback.is_wayback() && !opts.wayback.is_some())
+                        || (wayback.is_wayback() && opts.wayback.is_some())
+                        || t.is_thread_key_required)
+            })
             .flat_map(|t| {
                 let mut threads: Vec<Element> = vec![];
 

--- a/src/nicodo/comment_body.rs
+++ b/src/nicodo/comment_body.rs
@@ -52,15 +52,20 @@ pub struct Options<'a, 'b, 'c, 'd> {
     pub info: &'a Info,
     // pub counter_rs: usize,
     // pub counter_ps: usize,
-    pub wayback: Option<WaybackOptions<'b, 'c, 'd>>,
+    pub wayback: Option<WaybackOptions<'b>>,
+    pub official: Option<OfficialOptions<'c, 'd>>,
 }
 
 #[derive(Debug)]
-pub struct WaybackOptions<'a, 'b, 'c> {
+pub struct WaybackOptions<'a> {
     pub waybackkey: &'a str,
-    pub threadkey: &'b str,
-    pub force_184: &'c str,
     pub wayback: chrono::NaiveDateTime,
+}
+
+#[derive(Debug)]
+pub struct OfficialOptions<'a, 'b> {
+    pub threadkey: &'a str,
+    pub force_184: &'b str,
 }
 
 pub fn get_body(opts: Options) -> String {
@@ -103,14 +108,14 @@ pub fn get_body(opts: Options) -> String {
         scores: 1,
         nicoru: 3,
         res_from: if t.is_owner_thread { Some(-1000) } else { None },
-        threadkey: if let Some(w) = opts.wayback.as_ref() {
+        threadkey: if let Some(w) = opts.official.as_ref() {
             Some(w.threadkey.to_string())
         } else if t.is_thread_key_required {
             t.thread_key.clone()
         } else {
             None
         },
-        force_184: if let Some(w) = opts.wayback.as_ref() {
+        force_184: if let Some(w) = opts.official.as_ref() {
             Some(w.force_184.to_string())
         } else if t.is_184_forced.unwrap_or(false) {
             Some("1".to_string())

--- a/src/nicodo/info.rs
+++ b/src/nicodo/info.rs
@@ -31,8 +31,16 @@ impl Comment {
     pub fn thread_id<'a>(&'a self) -> Option<String> {
         self.threads
             .iter()
-            .find(|t| t.is_thread_key_required)
+            .find(|t| t.is_default_post_target)
             .map(|t| t.id.to_string())
+    }
+
+    pub fn is_thread_key_required<'a>(&'a self) -> bool {
+        self.threads.iter().all(|t| t.is_thread_key_required)
+    }
+
+    pub fn thread_key_required_thread<'a>(&'a self) -> Option<&CommentThread> {
+        self.threads.iter().find(|t| t.is_thread_key_required)
     }
 }
 


### PR DESCRIPTION
If we run this for videos that do not have a single thread with isThreadkeyRequired `true` (videos whose id does not start with `so`, or that are not official), you will get the error `invalid key`.

example: 
```
$ cargo run -- sm9                          
    Finished dev [unoptimized + debuginfo] target(s) in 0.05s
     Running `target/debug/nicodo sm9`
Video: sm9 (新・豪血寺一族 -煩悩解放 - レッツゴー！陰陽師)
Latest comments
invalid key
```

Based on information such as that on [this page](https://qiita.com/kumaS-kumachan/items/706123c9a4a5aff5517c#isthreadkeyrequired%E3%81%8Ctrue%E3%81%AE%E3%81%A8%E3%81%8D), it appears that `threadkey` and `force_184` are not required for non-official videos.
And further from the information on the same page, the values of `threadkey` and `force_184` can be obtained from within the thread.

With this change, I confirmed that the latest and past comments for official and unofficial videos can be retrieved.